### PR TITLE
Add navigation on tags and authors

### DIFF
--- a/resources/js/components/text-link.tsx
+++ b/resources/js/components/text-link.tsx
@@ -2,13 +2,17 @@ import { cn } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
 import { ComponentProps } from 'react';
 
-type LinkProps = ComponentProps<typeof Link>;
+type LinkProps = ComponentProps<typeof Link> & {
+    variant?: 'default' | 'ghost';
+};
 
-export default function TextLink({ className = '', children, ...props }: LinkProps) {
+export default function TextLink({ className = '', variant = 'default', children, ...props }: LinkProps) {
     return (
         <Link
             className={cn(
-                'text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500',
+                'text-foreground underline underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500',
+                variant === 'default' ? 'decoration-neutral-300' : '',
+                variant === 'ghost' ? 'decoration-transparent' : '',
                 className,
             )}
             {...props}

--- a/resources/js/pages/drafts/index.tsx
+++ b/resources/js/pages/drafts/index.tsx
@@ -1,5 +1,6 @@
 import DeleteLinkButton from '@/components/delete-link-button';
 import HeadingSmall from '@/components/heading-small';
+import TextLink from '@/components/text-link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Datetime } from '@/components/ui/datetime';
@@ -115,9 +116,9 @@ function DraftCard({ link }: { link: LinkData }) {
         <Card>
             <CardHeader>
                 <div className="flex items-baseline justify-between">
-                    <Link href={route('drafts.edit', link.id)}>
+                    <TextLink href={route('drafts.edit', link.id)} variant="ghost">
                         <CardTitle>{link.url}</CardTitle>
-                    </Link>
+                    </TextLink>
                     <div className="flex space-x-2">
                         <a href={link.url} target="_blank">
                             <ArrowUpRight></ArrowUpRight>
@@ -136,7 +137,9 @@ function DraftCard({ link }: { link: LinkData }) {
                 {link.tags.length > 0 && (
                     <div className="flex flex-wrap gap-2">
                         {link.tags.map((tag) => (
-                            <Pill key={tag.id}>{tag.label}</Pill>
+                            <Link href={route('links.index', { tags: [tag.id] })} key={tag.id}>
+                                <Pill>{tag.label}</Pill>
+                            </Link>
                         ))}
                     </div>
                 )}
@@ -145,7 +148,9 @@ function DraftCard({ link }: { link: LinkData }) {
                 {link.author && (
                     <div className="flex gap-x-4">
                         <User />
-                        {link.author.name}
+                        <TextLink href={route('links.index', { author_id: link.author.id })} variant="ghost">
+                            {link.author.name}
+                        </TextLink>
                     </div>
                 )}
                 <div className="text-muted-foreground text-sm">

--- a/resources/js/pages/links/index.tsx
+++ b/resources/js/pages/links/index.tsx
@@ -1,3 +1,4 @@
+import TextLink from '@/components/text-link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
@@ -161,9 +162,9 @@ function LinkCard({ link }: { link: LinkData }) {
     return (
         <Card>
             <CardHeader className="flex-row items-baseline justify-between">
-                <Link href={route('links.show', link.id)}>
+                <TextLink href={route('links.show', link.id)} variant="ghost">
                     <CardTitle>{link.title}</CardTitle>
-                </Link>
+                </TextLink>
                 <a href={link.url} target="_blank">
                     <ArrowUpRight></ArrowUpRight>
                 </a>
@@ -177,7 +178,9 @@ function LinkCard({ link }: { link: LinkData }) {
                 {link.tags.length > 0 && (
                     <div className="flex flex-wrap gap-2">
                         {link.tags.map((tag) => (
-                            <Pill key={tag.id}>{tag.label}</Pill>
+                            <Link href={route('links.index', { tags: [tag.id] })} key={tag.id}>
+                                <Pill>{tag.label}</Pill>
+                            </Link>
                         ))}
                     </div>
                 )}
@@ -185,7 +188,10 @@ function LinkCard({ link }: { link: LinkData }) {
             <CardFooter className="flex justify-between">
                 {link.author ? (
                     <div className="flex gap-x-4">
-                        <User /> {link.author.name}
+                        <User />
+                        <TextLink href={route('links.index', { author_id: link.author.id })} variant="ghost">
+                            {link.author.name}
+                        </TextLink>
                     </div>
                 ) : (
                     <div></div>

--- a/resources/js/pages/links/show.tsx
+++ b/resources/js/pages/links/show.tsx
@@ -1,5 +1,6 @@
 import LinkData = App.Data.LinkData;
 import DeleteLinkButton from '@/components/delete-link-button';
+import TextLink from '@/components/text-link';
 import { Datetime } from '@/components/ui/datetime';
 import { Pill } from '@/components/ui/pill';
 import AppLayout from '@/layouts/app-layout';
@@ -46,7 +47,9 @@ export default function Show({ link }: { link: LinkData }) {
                     {link.tags.length > 0 && (
                         <div className="flex flex-wrap gap-2">
                             {link.tags.map((tag) => (
-                                <Pill key={tag.id}>{tag.label}</Pill>
+                                <Link href={route('links.index', { tags: [tag.id] })} key={tag.id}>
+                                    <Pill>{tag.label}</Pill>
+                                </Link>
                             ))}
                         </div>
                     )}
@@ -55,7 +58,9 @@ export default function Show({ link }: { link: LinkData }) {
                         {link.author ? (
                             <div className="flex gap-x-4">
                                 <User />
-                                {link.author.name}
+                                <TextLink href={route('links.index', { author_id: link.author.id })} variant="ghost">
+                                    {link.author.name}
+                                </TextLink>
                             </div>
                         ) : (
                             <div />


### PR DESCRIPTION
This pull request introduces a new `variant` prop to the `TextLink` component and updates its usage across multiple files to improve link styling and functionality. Additionally, links associated with tags and authors are now more interactive, enabling navigation to filtered pages. 

### Component Updates:
* [`resources/js/components/text-link.tsx`](diffhunk://#diff-f65d963c7d6a8730bb7e61ba2a99576455b81c3ea8edf735dff55044209496e6L5-R15): Added a `variant` prop (`default` or `ghost`) to the `TextLink` component for customizable link styling. Updated the `TextLink` implementation to support these variants.

### Integration of `TextLink`:
* [`resources/js/pages/drafts/index.tsx`](diffhunk://#diff-89172007eb0545b2416c6f0b2469d0534a2838462b5451ab44a4279decef4e91L118-R121): Replaced `Link` with `TextLink` in the `DraftCard` component for the draft edit link and author name, using the `ghost` variant for styling consistency. [[1]](diffhunk://#diff-89172007eb0545b2416c6f0b2469d0534a2838462b5451ab44a4279decef4e91L118-R121) [[2]](diffhunk://#diff-89172007eb0545b2416c6f0b2469d0534a2838462b5451ab44a4279decef4e91R151-R153)
* [`resources/js/pages/links/index.tsx`](diffhunk://#diff-745784cb537d537589cbbe114fb47faa89bdf27e0d5cadd544ba2074e91c9ee9L164-R167): Updated the `LinkCard` component to use `TextLink` for the link title and author name, applying the `ghost` variant for improved styling. [[1]](diffhunk://#diff-745784cb537d537589cbbe114fb47faa89bdf27e0d5cadd544ba2074e91c9ee9L164-R167) [[2]](diffhunk://#diff-745784cb537d537589cbbe114fb47faa89bdf27e0d5cadd544ba2074e91c9ee9L180-R194)
* [`resources/js/pages/links/show.tsx`](diffhunk://#diff-581cbc21dc551eb202a3a8b4939448a36ce65c44377c4f59a6c65187897fc35cR61-R63): Used `TextLink` for the author name in the `Show` page, with the `ghost` variant for styling.

### Enhanced Tag Links:
* [`resources/js/pages/drafts/index.tsx`](diffhunk://#diff-89172007eb0545b2416c6f0b2469d0534a2838462b5451ab44a4279decef4e91L139-R142): Made tag pills clickable by wrapping them with `Link` components to navigate to filtered pages based on tags.
* [`resources/js/pages/links/index.tsx`](diffhunk://#diff-745784cb537d537589cbbe114fb47faa89bdf27e0d5cadd544ba2074e91c9ee9L180-R194): Updated tag pills in the `LinkCard` component to be clickable, enabling navigation to tag-filtered pages.
* [`resources/js/pages/links/show.tsx`](diffhunk://#diff-581cbc21dc551eb202a3a8b4939448a36ce65c44377c4f59a6c65187897fc35cL49-R52): Wrapped tag pills with `Link` components for interactivity, allowing navigation to filtered pages based on tags.