### PR TITLE
Fallback ingesting drafts from mail html

### DIFF
--- a/app/Actions/IngestDraftMessage.php
+++ b/app/Actions/IngestDraftMessage.php
@@ -31,7 +31,7 @@ class IngestDraftMessage
     {
         $validator = Validator::make(
             [
-                'url' => $this->extractUrl($message->text()),
+                'url' => $this->extractUrl($this->extractBody($message)),
                 'title' => $message->subject(),
             ],
             [
@@ -48,6 +48,21 @@ class IngestDraftMessage
             $user,
             DraftFormData::fromMailIngest($validator->validated())
         );
+    }
+
+    private function extractBody(Message $message): ?string
+    {
+        $text = $message->text();
+        if ($text !== null) {
+            return $text;
+        }
+
+        $html = $message->html();
+        if ($html !== null) {
+            return strip_tags($html);
+        }
+
+        return null;
     }
 
     private function extractUrl(?string $text): ?string


### PR DESCRIPTION
This pull request enhances the `IngestDraftMessage` functionality to better handle messages with both text and HTML content. It introduces a new method to extract the message body and updates the related tests to ensure comprehensive coverage of these scenarios.

### Enhancements to message handling:

* Added a new `extractBody` method in `app/Actions/IngestDraftMessage.php` to prioritize extracting text content from messages and fallback to sanitized HTML content if text is unavailable. (`[app/Actions/IngestDraftMessage.phpR53-R67](diffhunk://#diff-b61a78a914cf9ee9eba3686bca3e4b84e160d808ff74403fcae8d189856df2f0R53-R67)`)
* Updated the `extractUrl` method to use the new `extractBody` method for URL extraction, improving flexibility in handling different message formats. (`[app/Actions/IngestDraftMessage.phpL34-R34](diffhunk://#diff-b61a78a914cf9ee9eba3686bca3e4b84e160d808ff74403fcae8d189856df2f0L34-R34)`)

### Improvements to test coverage:

* Enhanced the `IngestDraftMessageTest` suite to include scenarios for ingesting messages with HTML content, ensuring proper handling of HTML tags and links. (`[tests/Unit/Actions/IngestDraftMessageTest.phpL49-R131](diffhunk://#diff-f7522a73857d86c8795ac14af561c24e96c4af9729ed564745cebab9f4b67825L49-R131)`)
* Introduced new test cases to validate behavior when messages lack links, contain empty text and HTML, or have incomplete content. This ensures robust error handling and edge case coverage. (`[tests/Unit/Actions/IngestDraftMessageTest.phpL71-R148](diffhunk://#diff-f7522a73857d86c8795ac14af561c24e96c4af9729ed564745cebab9f4b67825L71-R148)`)
* Renamed existing test cases for clarity, such as specifying whether the test is for text or HTML content. (`[tests/Unit/Actions/IngestDraftMessageTest.phpL13-R13](diffhunk://#diff-f7522a73857d86c8795ac14af561c24e96c4af9729ed564745cebab9f4b67825L13-R13)`)