### PR TITLE
Limit subject length when ingesting drafts from mails

### DIFF
--- a/app/Actions/IngestDraftMessage.php
+++ b/app/Actions/IngestDraftMessage.php
@@ -32,7 +32,7 @@ class IngestDraftMessage
         $validator = Validator::make(
             [
                 'url' => $this->extractUrl($this->extractBody($message)),
-                'title' => $message->subject(),
+                'title' => $this->extractSubject($message),
             ],
             [
                 'url' => ['required', 'url'],
@@ -100,5 +100,15 @@ class IngestDraftMessage
         )~ixu';
 
         return str_replace('PROTOCOLS', $protocols, $pattern);
+    }
+
+    private function extractSubject(Message $message): ?string
+    {
+        $subject = $message->subject();
+        if ($subject === null) {
+            return null;
+        }
+
+        return Str::limit($subject, limit: 252);
     }
 }


### PR DESCRIPTION
This pull request introduces a new method to handle long message subjects by truncating them to a specific length, ensuring compatibility with the system. It also includes a corresponding unit test to validate this functionality.

### Changes to subject handling:

* [`app/Actions/IngestDraftMessage.php`](diffhunk://#diff-b61a78a914cf9ee9eba3686bca3e4b84e160d808ff74403fcae8d189856df2f0L35-R35): Replaced direct use of `Message::subject()` with a new `extractSubject` method, which truncates the subject to a maximum of 252 characters. This ensures that overly long subjects are handled gracefully. [[1]](diffhunk://#diff-b61a78a914cf9ee9eba3686bca3e4b84e160d808ff74403fcae8d189856df2f0L35-R35) [[2]](diffhunk://#diff-b61a78a914cf9ee9eba3686bca3e4b84e160d808ff74403fcae8d189856df2f0R104-R113)

### Unit test additions:

* [`tests/Unit/Actions/IngestDraftMessageTest.php`](diffhunk://#diff-f7522a73857d86c8795ac14af561c24e96c4af9729ed564745cebab9f4b67825R148-R181): Added a test case to verify that a draft message with a long subject is truncated correctly to 252 characters, followed by an ellipsis (`...`).