### PR TITLE
Clear prefetching when logged out

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,6 +21,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->configureDate();
         $this->configureModels();
+        $this->configureVite();
         $this->registerMacros();
     }
 
@@ -34,6 +36,11 @@ class AppServiceProvider extends ServiceProvider
         Model::shouldBeStrict(! app()->isProduction());
 
         Relation::enforceMorphMap([]);
+    }
+
+    private function configureVite(): void
+    {
+        Vite::useAggressivePrefetching();
     }
 
     private function registerMacros(): void

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
         "vite": "npm:rolldown-vite@^6.3.21"
     },
     "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.9.5",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.1.11",
         "lightningcss-linux-x64-gnu": "^1.30.1"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,9 +160,6 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(rolldown-vite@6.3.21(@types/node@22.16.0)(esbuild@0.25.5)(jiti@2.4.2))(rollup@4.44.1)(typescript@5.8.3)
     optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu':
-        specifier: 4.9.5
-        version: 4.9.5
       '@tailwindcss/oxide-linux-x64-gnu':
         specifier: ^4.1.11
         version: 4.1.11
@@ -1200,11 +1197,6 @@ packages:
 
   '@rollup/rollup-linux-x64-gnu@4.44.1':
     resolution: {integrity: sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.9.5':
-    resolution: {integrity: sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==}
     cpu: [x64]
     os: [linux]
 
@@ -3969,9 +3961,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.44.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.9.5':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.44.1':

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -1,4 +1,4 @@
-import { Head, useForm, usePage } from '@inertiajs/react';
+import { Head, router, useForm, usePage } from '@inertiajs/react';
 import { LoaderCircle } from 'lucide-react';
 import { FormEventHandler } from 'react';
 
@@ -36,6 +36,9 @@ export default function Login({ status, canResetPassword }: LoginProps) {
         e.preventDefault();
         post(route('login'), {
             onFinish: () => reset('password'),
+            // When the user was logged out but still on the application, prefetching a route can will store the 302 redirect to log in in the cache.
+            // After the user logs in, we want to flush the cache so that the next request will not redirect to the login page.
+            onSuccess: () => router.flushAll(),
         });
     };
 

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -36,7 +36,7 @@ export default function Login({ status, canResetPassword }: LoginProps) {
         e.preventDefault();
         post(route('login'), {
             onFinish: () => reset('password'),
-            // When the user was logged out but still on the application, prefetching a route can will store the 302 redirect to log in in the cache.
+            // When the user was logged out but still on the application, prefetching a route will store the 302 redirect to log in in the cache.
             // After the user logs in, we want to flush the cache so that the next request will not redirect to the login page.
             onSuccess: () => router.flushAll(),
         });


### PR DESCRIPTION
This pull request introduces changes to enhance route handling, implement aggressive prefetching for Vite, and update dependencies. The most significant updates include the addition of a `configureVite` method in the `AppServiceProvider`, removal of the `@rollup/rollup-linux-x64-gnu` dependency, and improvements to login route caching.

### Framework Enhancements:
* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR41-R45): Added the `configureVite` method to enable aggressive prefetching for Vite, improving application performance.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L69): Removed the `@rollup/rollup-linux-x64-gnu` dependency from `optionalDependencies`, aligning with updated package requirements.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL163-L165): Removed all references to `@rollup/rollup-linux-x64-gnu@4.9.5` from `importers`, `packages`, and `snapshots` sections, reflecting the dependency removal. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL163-L165) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1206-L1210) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3974-L3976)

### Route Handling Improvements:
* [`resources/js/pages/auth/login.tsx`](diffhunk://#diff-6dcdf3ad723e9f82263160236fdb941e99915e8171a4f807b8a95a5c2aa89841R39-R41): Added `router.flushAll()` in the login flow to clear cached redirects after a successful login, ensuring proper route handling.