### PR TITLE
Fix dashboard routes for random links when no link exist

### DIFF
--- a/app/Http/Controllers/Dashboard/RandomCommunityLinkController.php
+++ b/app/Http/Controllers/Dashboard/RandomCommunityLinkController.php
@@ -16,7 +16,7 @@ class RandomCommunityLinkController
             ->wherePublished()
             ->wherePublic()
             ->with(['author', 'user', 'tags'])
-            ->random();
+            ->randomOrFail();
 
         return JsonResource::make(CommunityLinkResource::from($link));
     }

--- a/app/Http/Controllers/Dashboard/RandomLinkController.php
+++ b/app/Http/Controllers/Dashboard/RandomLinkController.php
@@ -16,7 +16,7 @@ class RandomLinkController
         $link = $user->links()
             ->wherePublished()
             ->with(['author', 'tags'])
-            ->random();
+            ->randomOrFail();
 
         return JsonResource::make(LinkResource::from($link));
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ namespace App\Providers;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Vite;
@@ -47,7 +48,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Builder::macro(
             'random',
-            function () {
+            function (): ?Model {
                 $total = $this->toBase()->getCountForPagination();
 
                 if ($total === 0) {
@@ -56,6 +57,12 @@ class AppServiceProvider extends ServiceProvider
 
                 return $this->offset(random_int(0, $total - 1))->first();
             }
+        );
+
+        Builder::macro(
+            'randomOrFail',
+            fn (): Model => $this->random()
+                ?? throw tap(new ModelNotFoundException)->setModel($this->getModel()::class)
         );
     }
 }

--- a/tests/Feature/Dashboard/RandomCommunityLinkControllerTest.php
+++ b/tests/Feature/Dashboard/RandomCommunityLinkControllerTest.php
@@ -43,3 +43,10 @@ it('returns a random community link', function (): void {
             'tags' => [],
         ]);
 });
+
+it('returns not found if no link exist', function (): void {
+    $this
+        ->actingAs(User::factory()->createOne())
+        ->getJson(route('api.dashboard.random-community-link'))
+        ->assertNotFound();
+});

--- a/tests/Feature/Dashboard/RandomCommunityLinkControllerTest.php
+++ b/tests/Feature/Dashboard/RandomCommunityLinkControllerTest.php
@@ -44,7 +44,7 @@ it('returns a random community link', function (): void {
         ]);
 });
 
-it('returns not found if no link exist', function (): void {
+it('returns not found if no link was found', function (): void {
     $this
         ->actingAs(User::factory()->createOne())
         ->getJson(route('api.dashboard.random-community-link'))

--- a/tests/Feature/Dashboard/RandomLinkControllerTest.php
+++ b/tests/Feature/Dashboard/RandomLinkControllerTest.php
@@ -39,3 +39,10 @@ it('returns a random link', function (): void {
             'tags' => [],
         ]);
 });
+
+it('returns not found if no link was found', function (): void {
+    $this
+        ->actingAs(User::factory()->createOne())
+        ->getJson(route('api.dashboard.random-link'))
+        ->assertNotFound();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 use Soyhuce\Testing\Concerns\MocksActions;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -29,6 +30,7 @@ pest()->extend(Tests\TestCase::class)
             AuthenticationException::class,
             AuthorizationException::class,
             HttpException::class,
+            ModelNotFoundException::class,
             ValidationException::class,
         ]);
 


### PR DESCRIPTION
This pull request introduces a new `randomOrFail` macro for `Builder` to ensure proper handling of cases where no model is found, replacing the existing `random` method in relevant controllers. Additionally, it updates the test suite to cover scenarios where no model exists, ensuring robust error handling.

### Enhancements to `Builder` macros:
* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eL50-R51): Added `randomOrFail` macro to `Builder`, which throws a `ModelNotFoundException` when no model is found. Updated the `random` macro to return `null` explicitly when no model exists. [[1]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eL50-R51) [[2]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR61-R66)

### Updates to controllers:
* [`app/Http/Controllers/Dashboard/RandomCommunityLinkController.php`](diffhunk://#diff-be8735d689d1b3f31f09ecad071648f379c451462c0db5a31496e5150bedbd61L19-R19): Replaced `random` with `randomOrFail` to ensure proper error handling when no community link exists.
* [`app/Http/Controllers/Dashboard/RandomLinkController.php`](diffhunk://#diff-bea1f4876de07b5d2e66281327a8cd4f77ff76aa16fc7432596e4e405bc6cca1L19-R19): Replaced `random` with `randomOrFail` to ensure proper error handling when no link exists for the user.

### Test suite improvements:
* [`tests/Feature/Dashboard/RandomCommunityLinkControllerTest.php`](diffhunk://#diff-1060177d71236914e9e07413b37dd0e7b34e61ae9e00d75f2a8106921d0462a7R46-R52): Added a test case to verify that a `404 Not Found` response is returned when no community link exists.
* [`tests/Feature/Dashboard/RandomLinkControllerTest.php`](diffhunk://#diff-b0eb3633d9b667794aa3f2825997b16197480c68e6588e4968ef91f7e70707a8R42-R48): Added a test case to verify that a `404 Not Found` response is returned when no link exists for the user.

### Dependency updates:
* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR10): Imported `ModelNotFoundException` to support the `randomOrFail` macro.
* [`tests/Pest.php`](diffhunk://#diff-f1690c87bfa8aecd216efde2439aa080c5ec7e9439abd4ea7a2483489fc8a6f5R7): Added `ModelNotFoundException` to the list of exceptions handled during testing. [[1]](diffhunk://#diff-f1690c87bfa8aecd216efde2439aa080c5ec7e9439abd4ea7a2483489fc8a6f5R7) [[2]](diffhunk://#diff-f1690c87bfa8aecd216efde2439aa080c5ec7e9439abd4ea7a2483489fc8a6f5R33)